### PR TITLE
bugfix: prisma seed getRandomInt()

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -172,7 +172,7 @@ async function main() {
         let recipe_id = recipe_ids[getRandomInt(recipe_ids.length)].id;
         let ingredient_id = ingredient_ids[getRandomInt(ingredient_ids.length)].id;
         let tag_id = tag_ids[getRandomInt(tag_ids.length)].id;
-        let amount = getRandomInt(10);
+        let amount = getRandomInt(10) + 1;
 
         recipe_ingredient_link_data.push({
             recipe_id: recipe_id,
@@ -206,5 +206,5 @@ main()
   })
 
 function getRandomInt(max: number): number {
-    return Math.floor(Math.random() + 1 * max);
+    return Math.floor(Math.random() * max);
 }


### PR DESCRIPTION
Before:
<img width="289" alt="image" src="https://github.com/Hack-Weekly/mint-panda-recipe-app/assets/91957823/fc000527-0b0c-41e7-9be7-77575ea785eb">
<img width="482" alt="image" src="https://github.com/Hack-Weekly/mint-panda-recipe-app/assets/91957823/94db1f76-4ff4-4e26-ac56-bdcbaa8d9360">


After:
<img width="273" alt="image" src="https://github.com/Hack-Weekly/mint-panda-recipe-app/assets/91957823/aa525e64-3d62-4754-8144-3d7a1a5d768a">
<img width="489" alt="image" src="https://github.com/Hack-Weekly/mint-panda-recipe-app/assets/91957823/d294874d-4eb2-4545-aca4-8da392d084d4">


This would cause `let recipe_id = recipe_ids[getRandomInt(recipe_ids.length)].id;` to overflow by 1. 
Instead, `let amount = getRandomInt(10) + 1;`  was added the +1 to make sure amount don't return 0
